### PR TITLE
Wait for process to finish before requesting exitValue

### DIFF
--- a/src/main/java/com/squareup/osstrich/Cli.java
+++ b/src/main/java/com/squareup/osstrich/Cli.java
@@ -60,6 +60,11 @@ public final class Cli {
     } finally {
       process.destroy();
     }
+    try {
+      process.waitFor(30, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
     int exitValue = process.exitValue();
     if (exitValue != 0) {
       throw new IOException("Process returned " + exitValue + ":\n"


### PR DESCRIPTION
Resolves #17. This race condition can happen if exitValue() is called before the process is finished. Set to 30 seconds as a default, but can lower it if you want!