### PR TITLE
Support --force and --dry-run

### DIFF
--- a/src/main/java/com/squareup/osstrich/JavadocPublisher.java
+++ b/src/main/java/com/squareup/osstrich/JavadocPublisher.java
@@ -207,8 +207,13 @@ public final class JavadocPublisher {
   }
 
   private void gitCommitAndPush(String message) throws IOException {
-    cli.withCwd(directory).exec("git", "commit", "-m", message);
-    cli.withCwd(directory).exec("git", "push", "origin", "gh-pages");
+    if (dryRun) {
+      log.info(String.format("DRY-RUN: git commit -m %s", message));
+      log.info("DRY-RUN: git push origin gh-pages");
+    } else {
+      cli.withCwd(directory).exec("git", "commit", "-m", message);
+      cli.withCwd(directory).exec("git", "push", "origin", "gh-pages");
+    }
   }
 
   public static void main(String[] args) throws IOException {

--- a/src/main/java/com/squareup/osstrich/JavadocPublisher.java
+++ b/src/main/java/com/squareup/osstrich/JavadocPublisher.java
@@ -112,8 +112,13 @@ public final class JavadocPublisher {
     File versionText = new File(artifactDirectory, "version.txt");
 
     if (versionText.exists() && artifact.latestVersion.equals(readUtf8(versionText))) {
-      log.info(String.format("Skipping %s, artifact is up to date", artifactDirectory));
-      return false;
+      if (force) {
+        log.info(String.format("%s artifact is up to date, but downloading anyway due to --force",
+            artifactDirectory));
+      } else {
+        log.info(String.format("Skipping %s, artifact is up to date", artifactDirectory));
+        return false;
+      }
     }
 
     log.info(String.format("Downloading %s to %s", artifact, artifactDirectory));


### PR DESCRIPTION
This implements support for `--force` and `--dry-run` flags. They can be placed anywhere in the args as they'll be stripped first before the normal arg parsing (figured this was the cleanest approach).

Resolves #9 
Resolves #10

Let me know if you want to do the commit-but-not-push approach discussed in #9 